### PR TITLE
Added better error handling support in all views. Base view now has a ha...

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,6 +15,10 @@
         "ReUI": false,
         "Base64": false,
         "Canvas2Image": false,
-        "argos": false
+        "argos": false,
+        "describe": false,
+        "it": false,
+        "expect": false,
+        "spyOn": false
     }
 }

--- a/build/release.jsb2
+++ b/build/release.jsb2
@@ -95,6 +95,10 @@
           "path": "../src"
         },
         {
+          "text": "_ErrorHandleMixin.js",
+          "path": "../src"
+        },
+        {
           "text": "View.js",
           "path": "../src"
         },

--- a/src/View.js
+++ b/src/View.js
@@ -27,6 +27,7 @@
 define('argos/View', [
     'dojo/_base/declare',
     'dojo/_base/lang',
+    'dojo/_base/array',
     'dijit/_WidgetBase',
     './_ActionMixin',
     './_CustomizationMixin',
@@ -34,6 +35,7 @@ define('argos/View', [
 ], function(
     declare,
     lang,
+    array,
     _WidgetBase,
     _ActionMixin,
     _CustomizationMixin,
@@ -74,6 +76,15 @@ define('argos/View', [
          */
         titleText: 'Generic View',
         /**
+         * @property {Object}
+         * Localized error messages. One general error message, and messages by HTTP status code.
+         */
+        errorText: {
+            general: 'A server error occured.',
+            status: {
+            }
+        },
+        /**
          * This views toolbar layout that defines all toolbar items in all toolbars.
          * @property {Object}
          */
@@ -89,6 +100,88 @@ define('argos/View', [
         serviceName: false,
         connectionName: false,
         constructor: function() {
+        },
+        startup: function() {
+            this.inherited(arguments);
+            this.errorHandlers = this._createCustomizedLayout(this.createErrorHandlers(), 'error_handlers');
+        },
+        /**
+         * @property {Object}
+         * Http Error Status codes. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+         */
+        HTTP_STATUS: {
+            BAD_REQUEST: 400,
+            UNAUTHORIZED: 401,
+            PAYMENT_REQUIRED: 402,
+            FORBIDDEN: 403,
+            NOT_FOUND: 404,
+            METHOD_NOT_ALLOWED: 405,
+            NOT_ACCEPTABLE: 406,
+            PROXY_AUTH_REQUIRED: 407,
+            REQUEST_TIMEOUT: 408,
+            CONFLICT: 409,
+            GONE: 410,
+            LENGTH_REQUIRED: 411,
+            PRECONDITION_FAILED: 412,
+            REQUEST_ENTITY_TOO_LARGE: 413,
+            REQUEST_URI_TOO_LONG: 414,
+            UNSUPPORTED_MEDIA_TYPE: 415,
+            REQUESTED_RANGE_NOT_SATISFIABLE: 416,
+            EXPECTATION_FAILED: 417
+        },
+        /**
+         * @property {Array} errorHandlers
+         * Array of objects that should contain a name string property, test function, and handle function.
+         *
+         */
+        errorHandlers: null,
+
+        /**
+         * @return {Array} Returns an array of error handlers
+         */
+        createErrorHandlers: function() {
+            return this.errorHandlers || [];
+        },
+        /**
+         * Starts matching and executing errorHandlers.
+         * @param {Error} error Error to pass to the errorHandlers
+         */
+        handleError: function(error) {
+            if (!error) {
+                return;
+            }
+
+            var matches, noop, getNext, len;
+
+            noop = function() {};
+
+            matches = array.filter(this.errorHandlers, function(handler) {
+                return handler.test && handler.test.call(this, error);
+            }.bind(this));
+
+            len = matches.length;
+
+            getNext = function(index) {
+                // next() chain has ended, return a no-op so calling next() in the last chain won't error
+                if (index === len) {
+                    return noop;
+                }
+
+                // Return a closure with index and matches captured.
+                // The handle function can call its "next" param to continue the chain.
+                return function() {
+                    var nextHandler, nextFn;
+                    nextHandler = matches[index];
+                    nextFn = nextHandler && nextHandler.handle;
+
+                    nextFn.call(this, error, getNext(index + 1));
+                }.bind(this);
+            }.bind(this);
+
+            if (len > 0 && matches[0].handle) {
+                // Start the handle chain, the handle can call next() to continue the iteration
+                matches[0].handle.call(this, error, getNext(1));
+            }
         },
         /**
          * Called from {@link App#_viewTransitionTo Applications view transition handler} and returns
@@ -321,6 +414,18 @@ define('argos/View', [
         getSecurity: function(access) {
             return this.security;
         },
+        /**
+         * Gets the general error message, or the error message for the status code.
+         */
+        getErrorMessage: function(error) {
+            var message = this.errorText.general;
+
+            if (error) {
+                message = this.errorText.status[error.status] || this.errorText.general;
+            }
+
+            return message;
+        }
     });
 
     lang.setObject('Sage.Platform.Mobile.View', __class);

--- a/src/View.js
+++ b/src/View.js
@@ -23,6 +23,7 @@
  * @mixins argos._ActionMixin
  * @mixins argos._CustomizationMixin
  * @mixins argos._Templated
+ * @mixins argos._ErrorHandleMixin
  */
 define('argos/View', [
     'dojo/_base/declare',
@@ -31,7 +32,8 @@ define('argos/View', [
     'dijit/_WidgetBase',
     './_ActionMixin',
     './_CustomizationMixin',
-    './_Templated'
+    './_Templated',
+    './_ErrorHandleMixin'
 ], function(
     declare,
     lang,
@@ -39,9 +41,10 @@ define('argos/View', [
     _WidgetBase,
     _ActionMixin,
     _CustomizationMixin,
-    _Templated
+    _Templated,
+    _ErrorHandleMixin
 ) {
-    var __class = declare('argos.View', [_WidgetBase, _ActionMixin, _CustomizationMixin, _Templated], {
+    var __class = declare('argos.View', [_WidgetBase, _ActionMixin, _CustomizationMixin, _Templated, _ErrorHandleMixin], {
         /**
          * This map provides quick access to HTML properties, most notably the selected property of the container
          */
@@ -76,15 +79,6 @@ define('argos/View', [
          */
         titleText: 'Generic View',
         /**
-         * @property {Object}
-         * Localized error messages. One general error message, and messages by HTTP status code.
-         */
-        errorText: {
-            general: 'A server error occured.',
-            status: {
-            }
-        },
-        /**
          * This views toolbar layout that defines all toolbar items in all toolbars.
          * @property {Object}
          */
@@ -104,84 +98,6 @@ define('argos/View', [
         startup: function() {
             this.inherited(arguments);
             this.errorHandlers = this._createCustomizedLayout(this.createErrorHandlers(), 'error_handlers');
-        },
-        /**
-         * @property {Object}
-         * Http Error Status codes. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-         */
-        HTTP_STATUS: {
-            BAD_REQUEST: 400,
-            UNAUTHORIZED: 401,
-            PAYMENT_REQUIRED: 402,
-            FORBIDDEN: 403,
-            NOT_FOUND: 404,
-            METHOD_NOT_ALLOWED: 405,
-            NOT_ACCEPTABLE: 406,
-            PROXY_AUTH_REQUIRED: 407,
-            REQUEST_TIMEOUT: 408,
-            CONFLICT: 409,
-            GONE: 410,
-            LENGTH_REQUIRED: 411,
-            PRECONDITION_FAILED: 412,
-            REQUEST_ENTITY_TOO_LARGE: 413,
-            REQUEST_URI_TOO_LONG: 414,
-            UNSUPPORTED_MEDIA_TYPE: 415,
-            REQUESTED_RANGE_NOT_SATISFIABLE: 416,
-            EXPECTATION_FAILED: 417
-        },
-        /**
-         * @property {Array} errorHandlers
-         * Array of objects that should contain a name string property, test function, and handle function.
-         *
-         */
-        errorHandlers: null,
-
-        /**
-         * @return {Array} Returns an array of error handlers
-         */
-        createErrorHandlers: function() {
-            return this.errorHandlers || [];
-        },
-        /**
-         * Starts matching and executing errorHandlers.
-         * @param {Error} error Error to pass to the errorHandlers
-         */
-        handleError: function(error) {
-            if (!error) {
-                return;
-            }
-
-            var matches, noop, getNext, len;
-
-            noop = function() {};
-
-            matches = array.filter(this.errorHandlers, function(handler) {
-                return handler.test && handler.test.call(this, error);
-            }.bind(this));
-
-            len = matches.length;
-
-            getNext = function(index) {
-                // next() chain has ended, return a no-op so calling next() in the last chain won't error
-                if (index === len) {
-                    return noop;
-                }
-
-                // Return a closure with index and matches captured.
-                // The handle function can call its "next" param to continue the chain.
-                return function() {
-                    var nextHandler, nextFn;
-                    nextHandler = matches[index];
-                    nextFn = nextHandler && nextHandler.handle;
-
-                    nextFn.call(this, error, getNext(index + 1));
-                }.bind(this);
-            }.bind(this);
-
-            if (len > 0 && matches[0].handle) {
-                // Start the handle chain, the handle can call next() to continue the iteration
-                matches[0].handle.call(this, error, getNext(1));
-            }
         },
         /**
          * Called from {@link App#_viewTransitionTo Applications view transition handler} and returns
@@ -413,18 +329,6 @@ define('argos/View', [
          */
         getSecurity: function(access) {
             return this.security;
-        },
-        /**
-         * Gets the general error message, or the error message for the status code.
-         */
-        getErrorMessage: function(error) {
-            var message = this.errorText.general;
-
-            if (error) {
-                message = this.errorText.status[error.status] || this.errorText.general;
-            }
-
-            return message;
         }
     });
 

--- a/src/_EditBase.js
+++ b/src/_EditBase.js
@@ -603,7 +603,6 @@ define('argos/_EditBase', [
                 }, {
                     name: 'AlertError',
                     test: function(error) {
-                        // Alert all errors that are not precondition failed.
                         return error.status !== this.HTTP_STATUS.PRECONDITION_FAILED;
                     },
                     handle: function(error, next) {
@@ -611,7 +610,7 @@ define('argos/_EditBase', [
                         next();
                     }
                 }, {
-                    name: 'LogError',
+                    name: 'CatchAll',
                     test: function(error) {
                         return true;
                     },

--- a/src/_ErrorHandleMixin.js
+++ b/src/_ErrorHandleMixin.js
@@ -1,0 +1,120 @@
+/**
+ * @class argos._ErrorHandleMixin
+ * General mixin for handling errors in a chainable fashion.
+ * @alternateClassName _ErrorHandleMixin
+ */
+define('argos/_ErrorHandleMixin', [
+    'dojo/_base/declare',
+    'dojo/_base/lang',
+    'dojo/_base/array',
+], function(
+    declare,
+    lang,
+    array
+) {
+    var __class = declare('argos._ErrorHandleMixin', null, {
+        /**
+         * @property {Object}
+         * Localized error messages. One general error message, and messages by HTTP status code.
+         */
+        errorText: {
+            general: 'A server error occured.',
+            status: {
+            }
+        },
+        /**
+         * @property {Object}
+         * Http Error Status codes. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+         */
+        HTTP_STATUS: {
+            BAD_REQUEST: 400,
+            UNAUTHORIZED: 401,
+            PAYMENT_REQUIRED: 402,
+            FORBIDDEN: 403,
+            NOT_FOUND: 404,
+            METHOD_NOT_ALLOWED: 405,
+            NOT_ACCEPTABLE: 406,
+            PROXY_AUTH_REQUIRED: 407,
+            REQUEST_TIMEOUT: 408,
+            CONFLICT: 409,
+            GONE: 410,
+            LENGTH_REQUIRED: 411,
+            PRECONDITION_FAILED: 412,
+            REQUEST_ENTITY_TOO_LARGE: 413,
+            REQUEST_URI_TOO_LONG: 414,
+            UNSUPPORTED_MEDIA_TYPE: 415,
+            REQUESTED_RANGE_NOT_SATISFIABLE: 416,
+            EXPECTATION_FAILED: 417
+        },
+        /**
+         * @property {Array} errorHandlers
+         * Array of objects that should contain a name string property, test function, and handle function.
+         *
+         */
+        errorHandlers: null,
+
+        /**
+         * @return {Array} Returns an array of error handlers
+         */
+        createErrorHandlers: function() {
+            return this.errorHandlers || [];
+        },
+        /**
+         * Starts matching and executing errorHandlers.
+         * @param {Error} error Error to pass to the errorHandlers
+         */
+        handleError: function(error) {
+            if (!error) {
+                return;
+            }
+
+            var matches, noop, getNext, len;
+
+            noop = function() {};
+
+            matches = array.filter(this.errorHandlers, function(handler) {
+                return handler.test && handler.test.call(this, error);
+            }.bind(this));
+
+            len = matches.length;
+
+            getNext = function(index) {
+                // next() chain has ended, return a no-op so calling next() in the last chain won't error
+                if (index === len) {
+                    return noop;
+                }
+
+                // Return a closure with index and matches captured.
+                // The handle function can call its "next" param to continue the chain.
+                return function() {
+                    var nextHandler, nextFn;
+                    nextHandler = matches[index];
+                    nextFn = nextHandler && nextHandler.handle;
+
+                    nextFn.call(this, error, getNext(index + 1));
+                }.bind(this);
+            }.bind(this);
+
+            if (len > 0 && matches[0].handle) {
+                // Start the handle chain, the handle can call next() to continue the iteration
+                matches[0].handle.call(this, error, getNext(1));
+            }
+        },
+        /**
+         * Gets the general error message, or the error message for the status code.
+         */
+        getErrorMessage: function(error) {
+            var message = this.errorText.general;
+
+            if (error) {
+                message = this.errorText.status[error.status] || this.errorText.general;
+            }
+
+            return message;
+        }
+    });
+
+    lang.setObject('Sage.Platform.Mobile._ErrorHandleMixin', __class);
+    return __class;
+});
+

--- a/tests/View.js
+++ b/tests/View.js
@@ -1,0 +1,131 @@
+define('tests/View', ['dojo/_base/lang', 'argos/View'], function(lang, View) {
+    describe('argos.View', function() {
+        var createErrorHandlers = function() {
+            return [
+                {
+                    name: 'one',
+                    test: function(error) {
+                        return true;
+                    },
+                    handle: function(error, next) {
+                        next();
+                    }
+                }, {
+                    name: 'two',
+                    test: function(error) {
+                        return true;
+                    },
+                    handle: function(error, next) {
+                        next();
+                    }
+                }, {
+                    name: 'three',
+                    test: function(error) {
+                        return true;
+                    },
+                    handle: function(error, next) {
+                        next();
+                    }
+                }
+            ];
+        };
+
+        it('can execute error handlers in a chain', function(done) {
+            var view, errorMessage, count = 0;
+            view = new View();
+            errorMessage = 'A general error.';
+
+            view.errorHandlers = createErrorHandlers();
+            view.errorHandlers[0].test = function(error) {
+                expect(error.message).toBe(errorMessage);
+                return true;
+            };
+
+            view.errorHandlers[0].handle = function(error, next) {
+                        expect(error.message).toBe(errorMessage);
+                        expect(count).toBe(0);
+                        count++;
+                        next();
+            };
+
+            view.errorHandlers[1].test = function(error) {
+                expect(error.message).toBe(errorMessage);
+                return true;
+            };
+
+            view.errorHandlers[1].handle = function(error, next) {
+                expect(error.message).toBe(errorMessage);
+                expect(count).toBe(1);
+                count++;
+                next();
+            };
+
+            view.errorHandlers[2].test = function(error) {
+                expect(error.message).toBe(errorMessage);
+                return true;
+            };
+
+            view.errorHandlers[2].handle = function(error, next) {
+                expect(error.message).toBe(errorMessage);
+                expect(count).toBe(2);
+                view.destroy();
+                done();
+            };
+
+            view.handleError(new Error(errorMessage));
+        });
+
+        it('can match and skip error handlers', function() {
+            var view, errorMessage, first, second, third;
+            view = new View();
+            errorMessage = 'A general error.';
+
+            view.errorHandlers = createErrorHandlers();
+            first = view.errorHandlers[0];
+            second = view.errorHandlers[1];
+            third = view.errorHandlers[2];
+
+            spyOn(first, 'handle').and.callThrough();
+            spyOn(second, 'handle').and.callThrough();
+            spyOn(third, 'handle').and.callThrough();
+
+            first.test = function(error) {
+                return false;
+            };
+
+            view.handleError(new Error(errorMessage));
+
+            // First should be skipped (it was not matched)
+            expect(first.handle).not.toHaveBeenCalled();
+
+            // Second and third should still be called
+            expect(second.handle).toHaveBeenCalled();
+            expect(third.handle).toHaveBeenCalled();
+            view.destroy();
+        });
+
+        it('can skip remaining handlers by not calling next()', function() {
+            var view, errorMessage, first, second;
+            view = new View();
+            errorMessage = 'A general error.';
+
+            view.errorHandlers = createErrorHandlers();
+
+            first = view.errorHandlers[0];
+            second = view.errorHandlers[1];
+
+            first.handle = function(error, next) {
+                // We will omit calling next(), so remaining error handlers should not be invoked
+            };
+
+            spyOn(first, 'handle').and.callThrough();
+            spyOn(second, 'handle').and.callThrough();
+
+            view.handleError(new Error(errorMessage));
+            expect(first.handle).toHaveBeenCalled();
+            expect(second.handle).not.toHaveBeenCalled();
+            view.destroy();
+        });
+    });
+});
+

--- a/tests/index.html
+++ b/tests/index.html
@@ -58,6 +58,7 @@
         'tests/SearchWidgetTests',
         'tests/ToolbarTests',
         'tests/UtilityTests',
+        'tests/View',
         'tests/_EditBase',
         'tests/Fields/_FieldTests',
         'tests/Fields/LookupFieldTests',


### PR DESCRIPTION
...ndleError method that accepts an error object. This will iterate all registered error handlers, which will be an array that is customizable via the 'error_handlers' subset. See _EditBase and tests/View for examples on registering and chaining error handlers. Added a general view "getErrorMessage" which takes an error, and attempts to pull an error messaged based on the http status code and falls back to a general error.
# MBL-10823

@CHenrie Please review
