### PR TITLE
INFORCRM-22016: Prevent tools from taking their id as a title. It is …

### DIFF
--- a/src/MainToolbar.js
+++ b/src/MainToolbar.js
@@ -132,7 +132,7 @@ const __class = declare('argos.MainToolbar', [Toolbar], /** @lends argos.MainToo
       <button
         class="btn-icon {%= $.cls %} toolButton-right"
         type="button"
-        title="{%: $.title || $.id %}"
+        title="{%: $.title %}"
         data-action="invokeTool"
         data-tool="{%= $.id %}">
         {% if ($.svg) { %}


### PR DESCRIPTION
…not translated and will never be correct as a tooltip.