### PR TITLE
Fix bug where hiding fields in single column view would hide all fields

### DIFF
--- a/src-out/_EditBase.js
+++ b/src-out/_EditBase.js
@@ -373,7 +373,9 @@ define('argos/_EditBase', ['module', 'exports', 'dojo/_base/declare', 'dojo/_bas
      */
     _onHideField: function _onHideField(field) {
       $(field.containerNode).addClass('row-hidden');
-      $(field.containerNode).parent().addClass('display-none');
+      if (this.multiColumnView) {
+        $(field.containerNode).parent().addClass('display-none');
+      }
     },
     /**
      * Handler for a fields on enable event.

--- a/src/_EditBase.js
+++ b/src/_EditBase.js
@@ -433,7 +433,9 @@ const __class = declare('argos._EditBase', [View], /** @lends module:argos/_Edit
    */
   _onHideField: function _onHideField(field) {
     $(field.containerNode).addClass('row-hidden');
-    $(field.containerNode).parent().addClass('display-none');
+    if (this.multiColumnView) {
+      $(field.containerNode).parent().addClass('display-none');
+    }
   },
   /**
    * Handler for a fields on enable event.


### PR DESCRIPTION
Implementing a feature to disable a certain field on the login view
based on a configuration flag. The login view is not set to use the
multiColumnView flag. The display-none css class gets applied to the
div containing all the fields if one of the child fields hides itself.

Refs: INFORCRM-3403