### PR TITLE
Fix getting the value of a decimal field when a currency symbol is added

### DIFF
--- a/src-out/Fields/DecimalField.js
+++ b/src-out/Fields/DecimalField.js
@@ -95,7 +95,7 @@ define('argos/Fields/DecimalField', ['module', 'exports', 'dojo/_base/declare', 
     getValue: function getValue() {
       var value = this.inherited(getValue, arguments);
       // SData (and other functions) expect American formatted numbers
-      value = value.replace(Mobile.CultureInfo.numberFormat.currencyGroupSeparator, '').replace(Mobile.CultureInfo.numberFormat.numberGroupSeparator, '').replace(Mobile.CultureInfo.numberFormat.currencyDecimalSeparator, '.').replace(Mobile.CultureInfo.numberFormat.numberDecimalSeparator, '.');
+      value = value.replace(Mobile.CultureInfo.numberFormat.currencySymbol, '').replace(Mobile.CultureInfo.numberFormat.currencyGroupSeparator, '').replace(Mobile.CultureInfo.numberFormat.numberGroupSeparator, '').replace(Mobile.CultureInfo.numberFormat.currencyDecimalSeparator, '.').replace(Mobile.CultureInfo.numberFormat.numberDecimalSeparator, '.');
       return parseFloat(value);
     },
     /**

--- a/src/Fields/DecimalField.js
+++ b/src/Fields/DecimalField.js
@@ -82,6 +82,7 @@ const control = declare('argos.Fields.DecimalField', [TextField], /** @lends mod
     let value = this.inherited(getValue, arguments);
     // SData (and other functions) expect American formatted numbers
     value = value
+      .replace(Mobile.CultureInfo.numberFormat.currencySymbol, '')
       .replace(Mobile.CultureInfo.numberFormat.currencyGroupSeparator, '')
       .replace(Mobile.CultureInfo.numberFormat.numberGroupSeparator, '')
       .replace(Mobile.CultureInfo.numberFormat.currencyDecimalSeparator, '.')

--- a/tests/Fields/DecimalFieldTests.js
+++ b/tests/Fields/DecimalFieldTests.js
@@ -1,102 +1,103 @@
+/* eslint-disable */
 define('tests/Fields/DecimalFieldTests', ['dojo/query','dojo/dom-attr','dojo/dom-class','argos/Fields/DecimalField'], function(query, domAttr, domClass, DecimalField) {
 return describe('Sage.Platform.Mobile.Fields.DecimalField', function() {
 
-    it('Can rouund to 2 decimal places', function() {
+    it('Can round to 2 decimal places', function() {
         var field = new DecimalField();
         var value = 0.001
         field.setValue(value);
         expect(field.getValue()).toEqual(0.00);
     });
-   
-    it('Can rouund to 2 decimal places down', function() {
+
+    it('Can round to 2 decimal places down', function() {
         var field = new DecimalField();
         var value = 0.554
         field.setValue(value);
         expect(field.getValue()).toEqual(0.55);
     });
-    it('Can rouund to 2 decimal places up', function() {
+    it('Can round to 2 decimal places up', function() {
         var field = new DecimalField();
         var value = 0.555;
         field.setValue(value);
         expect(field.getValue()).toEqual(0.56);
     });
-    it('Can rouund to 2 decimal places down', function() {
+    it('Can round to 2 decimal places down', function() {
         var field = new DecimalField();
         var value = 0.554;
         field.setValue(value);
         expect(field.getValue()).toEqual(0.55);
     });
-    it('Can rouund to 0 decimal places up', function() {
+    it('Can round to 0 decimal places up', function() {
         var field = new DecimalField();
         var value = 0.55;
         field.precision = 0;
         field.setValue(value);
         expect(field.getValue()).toEqual(1);
     });
-    it('Can rouund to 0 decimal places up', function() {
+    it('Can round to 0 decimal places up', function() {
         var field = new DecimalField();
         var value = 1000.55;
         field.precision = 0;
         field.setValue(value);
         expect(field.getValue()).toEqual(1001.00);
     });
-    it('Can rouund to 0 decimal places down', function() {
+    it('Can round to 0 decimal places down', function() {
         var field = new DecimalField();
         var value = 1000.25;
         field.precision = 0;
         field.setValue(value);
         expect(field.getValue()).toEqual(1000.00);
     });
-    it('Can rouund to 1 decimal places up', function() {
+    it('Can round to 1 decimal places up', function() {
         var field = new DecimalField();
         var value = 0.55;
         field.precision = 1;
         field.setValue(value);
         expect(field.getValue()).toEqual(0.6);
     });
-    it('Can rouund to 1 decimal places up', function() {
+    it('Can round to 1 decimal places up', function() {
         var field = new DecimalField();
         var value = 1000.55;
         field.precision = 1;
         field.setValue(value);
         expect(field.getValue()).toEqual(1000.6);
     });
-    it('Can rouund to 1 decimal places down', function() {
+    it('Can round to 1 decimal places down', function() {
         var field = new DecimalField();
         var value = 1000.24;
         field.precision = 1;
         field.setValue(value);
         expect(field.getValue()).toEqual(1000.2);
     });
-    it('Can rouund to 3 decimal places up', function() {
+    it('Can round to 3 decimal places up', function() {
         var field = new DecimalField();
         var value = 0.5568;
         field.precision = 3;
         field.setValue(value);
         expect(field.getValue()).toEqual(0.557);
     });
-    it('Can rouund to 3 decimal places up', function() {
+    it('Can round to 3 decimal places up', function() {
         var field = new DecimalField();
         var value = 1000.5559;
         field.precision = 3;
         field.setValue(value);
         expect(field.getValue()).toEqual(1000.556);
     });
-    it('Can rouund to 3 decimal places down', function() {
+    it('Can round to 3 decimal places down', function() {
         var field = new DecimalField();
         var value = 1000.24;
         field.precision = 3;
         field.setValue(value);
         expect(field.getValue()).toEqual(1000.240);
     });
-    it('Can rouund to 3 decimal places down', function() {
+    it('Can round to 3 decimal places down', function() {
         var field = new DecimalField();
         var value = 1000.2434;
         field.precision = 3;
         field.setValue(value);
         expect(field.getValue()).toEqual(1000.243);
     });
-    it('Can rouund to invaild  decimal places defaults to culture', function() {
+    it('Can round to invaild  decimal places defaults to culture', function() {
         var field = new DecimalField();
         var value = 1000.2434;
         field.precision = null;
@@ -116,5 +117,19 @@ return describe('Sage.Platform.Mobile.Fields.DecimalField', function() {
         field.setValue(value);
         expect(field.getValue()).toEqual(0);
     });
+    it('Can parse a number with currency symbol', function() {
+        var field = new DecimalField();
+        var value = '$1,000,000.00';
+        field.inputNode.value = value;
+        expect(field.getValue()).toEqual(1000000);
+
+        value = '$9,000.50';
+        field.inputNode.value = value;
+        expect(field.getValue()).toEqual(9000.50);
+
+        value = '$0.50';
+        field.inputNode.value = value;
+        expect(field.getValue()).toEqual(0.50);
+    })
 });
 });

--- a/tests/Fields/LookupFieldTests.js
+++ b/tests/Fields/LookupFieldTests.js
@@ -68,7 +68,7 @@ define('tests/Fields/LookupFieldTests', [
             // Default
             options = field.createNavigationOptions();
             expect(options.singleSelect).toEqual(field.singleSelect);
-            expect(options.tools.tbar[0].cls).toBe('display-none');
+            expect(options.tools.tbar[1].cls).toBe('display-none');
 
             // No singleSelectionAction specified, defaults to 'complete'
             field.singleSelectAction = '';


### PR DESCRIPTION
Trying to get the value of the decimal field when a currency symbol is
present causes the parse to fail and returning NaN. This in turn causes
a validation error to occur on the field and the user is displayed a
message that 'NaN' is not a valid number.

Fixes: INFORCRM-12770