### PR TITLE
Fix issues when decimal had more than two group separators

### DIFF
--- a/GruntRunnerBasic.tmpl
+++ b/GruntRunnerBasic.tmpl
@@ -12,6 +12,18 @@
     <script src="<%= script %>"></script>
     <% }) %>
   <% }; %>
+
+  <!-- Soho Configuration -->
+  <script type="application/javascript">
+    var SohoConfig = {
+      culturesPath: 'libraries/soho/js/cultures/',
+      minifyCultures: false,
+      personalize: {
+        noInit: true
+      }
+    };
+  </script>
+
   <!-- SData Client Library -->
   <script type="text/javascript" src="libraries/sdata/sdata-client-dependencies-debug.js"></script>
   <script type="text/javascript" src="libraries/sdata/sdata-client-debug.js"></script>
@@ -111,13 +123,15 @@
 
       <% with (scripts) { %>
       var ctx = buildContext();
-      ctx.ready(function() {
-        define('jquery', function() {
-          return window.$;
+      Soho.Locale.set('en-US').done(function() {
+        ctx.ready(function() {
+          define('jquery', function() {
+            return window.$;
+          });
+          require([
+            'tests/all'
+          ]);
         });
-        require([
-          'tests/all'
-        ]);
       });
 
       require([

--- a/src-out/Fields/DecimalField.js
+++ b/src-out/Fields/DecimalField.js
@@ -71,20 +71,16 @@ define('argos/Fields/DecimalField', ['module', 'exports', 'dojo/_base/declare', 
      * @param {Number/String} val Value to be set
      */
     setValue: function setValue(val) {
-      var perc = this.getPrecision();
-      var newVal = _Utility2.default.roundNumberTo(parseFloat(val), perc);
-      newVal = newVal.toFixed(perc);
-      if (isNaN(newVal)) {
-        if (perc === 0) {
-          newVal = '0';
-        } else {
-          newVal = '0' + (Mobile.CultureInfo.numberFormat.currencyDecimalSeparator || '.') + '00';
-        }
-      } else {
-        if (perc !== 0) {
-          newVal = '' + parseInt(newVal, 10) + (Mobile.CultureInfo.numberFormat.currencyDecimalSeparator || '.') + newVal.substr(-perc);
-        }
-      }
+      var precision = this.getPrecision();
+      var parsed = _Utility2.default.roundNumberTo(parseFloat(val), precision);
+      parsed = Number.isNaN(parsed) ? 0 : parsed;
+      var newVal = Soho.Locale.formatNumber(parsed, {
+        style: 'decimal',
+        minimumFractionDigits: precision,
+        maximumFractionDigits: precision,
+        round: false
+      });
+
       this.inherited(setValue, arguments, [newVal]);
     },
     /**
@@ -94,8 +90,9 @@ define('argos/Fields/DecimalField', ['module', 'exports', 'dojo/_base/declare', 
      */
     getValue: function getValue() {
       var value = this.inherited(getValue, arguments);
-      // SData (and other functions) expect American formatted numbers
-      value = value.replace(Mobile.CultureInfo.numberFormat.currencySymbol, '').replace(Mobile.CultureInfo.numberFormat.currencyGroupSeparator, '').replace(Mobile.CultureInfo.numberFormat.numberGroupSeparator, '').replace(Mobile.CultureInfo.numberFormat.currencyDecimalSeparator, '.').replace(Mobile.CultureInfo.numberFormat.numberDecimalSeparator, '.');
+      var data = Soho.Locale.currentLocale.data;
+      // // SData (and other functions) expect American formatted numbers
+      value = value.replace(data.currencySign, '').replace(data.numbers.percentSign, '').replace(new RegExp(data.numbers.group, 'ig'), '').replace(data.numbers.decimal, '.');
       return parseFloat(value);
     },
     /**

--- a/src/Fields/DecimalField.js
+++ b/src/Fields/DecimalField.js
@@ -57,20 +57,16 @@ const control = declare('argos.Fields.DecimalField', [TextField], /** @lends mod
    * @param {Number/String} val Value to be set
    */
   setValue: function setValue(val) {
-    const perc = this.getPrecision();
-    let newVal = Utility.roundNumberTo(parseFloat(val), perc);
-    newVal = newVal.toFixed(perc);
-    if (isNaN(newVal)) {
-      if (perc === 0) {
-        newVal = '0';
-      } else {
-        newVal = `0${Mobile.CultureInfo.numberFormat.currencyDecimalSeparator || '.'}00`;
-      }
-    } else {
-      if (perc !== 0) {
-        newVal = `${parseInt(newVal, 10)}${Mobile.CultureInfo.numberFormat.currencyDecimalSeparator || '.'}${newVal.substr(-perc)}`;
-      }
-    }
+    const precision = this.getPrecision();
+    let parsed = Utility.roundNumberTo(parseFloat(val), precision);
+    parsed = Number.isNaN(parsed) ? 0 : parsed;
+    const newVal = Soho.Locale.formatNumber(parsed, {
+      style: 'decimal',
+      minimumFractionDigits: precision,
+      maximumFractionDigits: precision,
+      round: false,
+    });
+
     this.inherited(setValue, arguments, [newVal]);
   },
   /**
@@ -80,13 +76,13 @@ const control = declare('argos.Fields.DecimalField', [TextField], /** @lends mod
    */
   getValue: function getValue() {
     let value = this.inherited(getValue, arguments);
-    // SData (and other functions) expect American formatted numbers
+    const data = Soho.Locale.currentLocale.data;
+    // // SData (and other functions) expect American formatted numbers
     value = value
-      .replace(Mobile.CultureInfo.numberFormat.currencySymbol, '')
-      .replace(Mobile.CultureInfo.numberFormat.currencyGroupSeparator, '')
-      .replace(Mobile.CultureInfo.numberFormat.numberGroupSeparator, '')
-      .replace(Mobile.CultureInfo.numberFormat.currencyDecimalSeparator, '.')
-      .replace(Mobile.CultureInfo.numberFormat.numberDecimalSeparator, '.');
+      .replace(data.currencySign, '')
+      .replace(data.numbers.percentSign, '')
+      .replace(new RegExp(data.numbers.group, 'ig'), '')
+      .replace(data.numbers.decimal, '.');
     return parseFloat(value);
   },
   /**

--- a/tests/Fields/DecimalFieldTests.js
+++ b/tests/Fields/DecimalFieldTests.js
@@ -34,7 +34,7 @@ return describe('Sage.Platform.Mobile.Fields.DecimalField', function() {
         field.setValue(value);
         expect(field.getValue()).toEqual(1);
     });
-    it('Can round to 0 decimal places up', function() {
+    it('Can round to 0 decimal places up 2', function() {
         var field = new DecimalField();
         var value = 1000.55;
         field.precision = 0;
@@ -119,9 +119,9 @@ return describe('Sage.Platform.Mobile.Fields.DecimalField', function() {
     });
     it('Can parse a number with currency symbol', function() {
         var field = new DecimalField();
-        var value = '$1,000,000.00';
+        var value = '$1,000,000,000.00';
         field.inputNode.value = value;
-        expect(field.getValue()).toEqual(1000000);
+        expect(field.getValue()).toEqual(1000000000);
 
         value = '$9,000.50';
         field.inputNode.value = value;

--- a/tests/index.html
+++ b/tests/index.html
@@ -4,6 +4,17 @@
 
 <head>
   <title>Argos-sdk Test Runner</title>
+
+    <!-- Soho Configuration -->
+    <script type="application/javascript">
+      var SohoConfig = {
+        culturesPath: '../libraries/soho/js/cultures/',
+        minifyCultures: false,
+        personalize: {
+          noInit: true
+        }
+      };
+    </script>
   <!-- jasmine -->
   <link rel="stylesheet" type="text/css" href="../libraries/jasmine-2.0.0/jasmine.css">
   <script type="text/javascript" src="../libraries/jasmine-2.0.0/jasmine.js"></script>
@@ -35,7 +46,7 @@
   <script type="text/javascript" src="../libraries/l20n/l20n.js"></script>
 
   <!-- jQuery -->
-  <script type="text/javascript" src="../libraries/soho/js/jquery-3.4.1.js"></script>
+  <script type="text/javascript" src="../libraries/soho/js/jquery-3.5.1.js"></script>
 
   <!-- SohoXi -->
   <script type="text/javascript" src="../libraries/soho/js/sohoxi.js"></script>
@@ -114,7 +125,8 @@
       return ctx;
     }
     var ctx = buildContext();
-    ctx.ready(function() {
+    Soho.Locale.set('en-US').done(function() {
+      ctx.ready(function() {
       // Shim, sohoxi will use define.amd and require it.
       define('jquery', function() {
         return window.$;
@@ -123,6 +135,8 @@
         'tests/all'
       ]);
     });
+    });
+
     require(['../libraries/jasmine-2.0.0/boot.js']);
 
   </script>


### PR DESCRIPTION
Removing some uses of Mobile.CultureInfo to use Soho.Locale instead.
In the process of this conversion, I discovered a bug in our current
decimal field's getValue function. String.prototype.replace will
only replace one value, not multiple. This happened to be called
twice allowing it to work in the millions, but would break if that
number reached billions. Switched the group separator to use a regex
with global flags to replace all.